### PR TITLE
Add Jellycuts version of JIT Enabler shortcut

### DIFF
--- a/JIT Backend/JELLYCUTS_README.md
+++ b/JIT Backend/JELLYCUTS_README.md
@@ -1,0 +1,139 @@
+# JIT Enabler Shortcut (Jellycuts Version)
+
+This document explains how to use the Jellycuts version of the JIT Enabler shortcut to enable Just-In-Time (JIT) compilation for iOS apps.
+
+## What is Jellycuts?
+
+Jellycuts is a programming language and development environment that allows you to create iOS Shortcuts using code instead of the visual editor. This makes it easier to share, modify, and understand complex shortcuts.
+
+## Why Use Jellycuts for JIT Enabler?
+
+1. **No Signing Required**: The Jellycuts version doesn't require signing, making it easier to distribute
+2. **Easier to Customize**: Users can modify the shortcut to fit their specific needs
+3. **Better Readability**: The code-based format is easier to understand than the JSON format
+4. **Version Control**: Changes can be tracked more effectively
+
+## Installation Instructions
+
+### Step 1: Install Jellycuts
+
+1. Download Jellycuts from the App Store: [Jellycuts on the App Store](https://apps.apple.com/us/app/jellycuts/id1522625245)
+2. Open the Jellycuts app and complete the initial setup
+
+### Step 2: Import the JIT Enabler Shortcut
+
+1. Download the `JIT_Enabler.jellycuts` file from our website
+2. Open the Jellycuts app
+3. Tap the "+" button to create a new shortcut
+4. Select "Import" and choose the downloaded file
+5. Review the code (you can make any customizations if needed)
+6. Tap "Build" to compile the shortcut
+
+### Step 3: Configure the Shortcut
+
+When building the shortcut, you'll be prompted to enter:
+- The URL of your JIT Backend (e.g., `https://your-jit-backend.onrender.com`)
+
+### Step 4: Add to Your Shortcuts Library
+
+After building, Jellycuts will prompt you to add the shortcut to your Shortcuts library. Tap "Add Shortcut" to complete the installation.
+
+## Using the JIT Enabler Shortcut
+
+1. Run the JIT Enabler shortcut from the Shortcuts app
+2. The first time you run it, the shortcut will register your device with the JIT backend
+3. Select the app category (Emulators, JavaScript Apps, or Other Apps)
+4. Choose a specific app or enter a bundle ID
+5. The shortcut will communicate with the backend to enable JIT
+6. Once JIT is enabled, the app will launch automatically
+
+## Troubleshooting
+
+### Common Issues
+
+1. **Connection Error**: If you see "Network error", check your internet connection and make sure the backend URL is correct
+2. **Authentication Error**: If you see "Device not registered", try deleting the shortcut and reinstalling it
+3. **JIT Enablement Failure**: If JIT enablement fails, check that you're using the correct bundle ID and that your iOS version is supported
+
+### Resetting the Shortcut
+
+If you need to reset the shortcut:
+1. Open the Shortcuts app
+2. Long-press on the JIT Enabler shortcut
+3. Select "Delete Shortcut"
+4. Reinstall using the steps above
+
+## Advanced Customization
+
+The Jellycuts format makes it easy to customize the shortcut. Here are some common customizations:
+
+### Adding More Apps
+
+To add more predefined apps, find the appropriate section in the code and add your app:
+
+```javascript
+// Handle Your App
+If({
+    input: GetVariable("Chosen Item"),
+    condition: "is",
+    value: "Your App Name",
+    then: [
+        Text("com.example.yourapp"),
+        SetVariable("bundleID")
+    ]
+})
+```
+
+### Changing Backend URL
+
+If you need to change the backend URL after installation:
+1. Open the Shortcuts app
+2. Edit the JIT Enabler shortcut
+3. Find the "Text" action at the beginning
+4. Change the URL to your new backend
+
+## Security Considerations
+
+- The shortcut generates a pseudo-UDID based on your device characteristics
+- All communication with the backend is encrypted using HTTPS
+- Your device token is stored securely on your device
+- No sensitive information is shared with third parties
+
+## Technical Details
+
+The Jellycuts shortcut performs the following operations:
+
+1. **Device Registration**:
+   - Collects device information (name, model, iOS version)
+   - Generates a pseudo-UDID using a hash function
+   - Registers with the backend server
+   - Stores the authentication token
+
+2. **App Selection**:
+   - Provides categorized lists of common apps
+   - Allows manual entry of bundle IDs
+   - Maps friendly names to bundle IDs
+
+3. **JIT Enablement**:
+   - Sends the bundle ID to the backend
+   - Receives JIT enablement instructions
+   - Processes the response
+   - Launches the target app
+
+4. **Error Handling**:
+   - Detects and reports network errors
+   - Handles authentication failures
+   - Provides user-friendly error messages
+
+## Compatibility
+
+- **iOS Versions**: Compatible with iOS 15, 16, and 17
+- **Device Types**: Works on iPhone and iPad
+- **App Types**: Compatible with emulators, JavaScript-based apps, and other apps that use JIT compilation
+
+## Support
+
+If you encounter any issues with the JIT Enabler shortcut, please:
+1. Check the troubleshooting section above
+2. Visit our website for updated documentation
+3. Contact support with details about your device and the specific error

--- a/JIT Backend/JIT_Enabler.jellycuts
+++ b/JIT Backend/JIT_Enabler.jellycuts
@@ -1,0 +1,321 @@
+// JIT Enabler Shortcut
+// Created with Jellycuts
+// This shortcut enables JIT compilation for iOS apps
+
+import { Shortcut, ShowResult, GetVariable, SetVariable, Dictionary, Text, URL, GetContentsOfURL, If, Menu, List, Ask, RunJavaScript, OpenApp, Nothing, Comment, GetDeviceDetails } from "jellycuts";
+
+// Create the shortcut
+const shortcut = new Shortcut("JIT Enabler");
+
+// Set shortcut icon
+shortcut.icon = {
+    color: "blue",
+    glyph: "bolt.fill"
+};
+
+// Import questions
+shortcut.importQuestion("backendURL", "What is the URL of your JIT Backend?", "https://your-jit-backend.onrender.com");
+
+// Add comment explaining the shortcut
+shortcut.add(
+    Comment("JIT Enabler Shortcut\nThis shortcut enables JIT compilation for iOS apps by communicating with a JIT backend server.")
+);
+
+// Set backend URL from import question
+shortcut.add(
+    Text("{{backendURL}}"),
+    SetVariable("backendURL")
+);
+
+// Get device information
+shortcut.add(
+    GetDeviceDetails("Device Name"),
+    SetVariable("deviceName"),
+    
+    GetDeviceDetails("System Version"),
+    SetVariable("iosVersion"),
+    
+    GetDeviceDetails("Device Model"),
+    SetVariable("deviceModel")
+);
+
+// Generate a pseudo-UDID using JavaScript
+const generateUDIDScript = `
+// Generate a unique device identifier based on device properties
+const deviceName = args.shortcutParameter.deviceName;
+const deviceModel = args.shortcutParameter.deviceModel;
+const iosVersion = args.shortcutParameter.iosVersion;
+
+// Create a string with device info
+const deviceInfoString = \`\${deviceName}-\${deviceModel}-\${iosVersion}-\${Date.now()}\`;
+
+// Hash the string to create a pseudo-UDID
+function hashString(str) {
+  let hash = 0;
+  if (str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = ((hash << 5) - hash) + char;
+    hash = hash & hash;
+  }
+  return hash.toString(16).replace('-', '');
+}
+
+const pseudoUDID = hashString(deviceInfoString);
+return pseudoUDID;
+`;
+
+shortcut.add(
+    RunJavaScript(generateUDIDScript, {
+        deviceName: GetVariable("deviceName"),
+        deviceModel: GetVariable("deviceModel"),
+        iosVersion: GetVariable("iosVersion")
+    }),
+    SetVariable("deviceUDID")
+);
+
+// Check if we already have a JIT token
+shortcut.add(
+    If({
+        input: GetVariable("jitToken"),
+        condition: "matches",
+        value: "^(?!.+)$", // Regex to check if empty
+        then: [
+            // Show registration message
+            ShowResult("Registering your device with JIT Backend..."),
+            
+            // Create registration URL
+            URL(GetVariable("backendURL") + "/register"),
+            
+            // Create registration data
+            Dictionary({
+                "udid": GetVariable("deviceUDID"),
+                "device_name": GetVariable("deviceName"),
+                "ios_version": GetVariable("iosVersion"),
+                "device_model": GetVariable("deviceModel")
+            }),
+            
+            // Send registration request
+            GetContentsOfURL({
+                url: GetVariable("backendURL") + "/register",
+                method: "POST",
+                headers: {
+                    "Content-Type": "application/json"
+                },
+                body: "JSON"
+            }),
+            
+            // Extract and save token
+            GetVariable("Value For 'token'"),
+            SetVariable("jitToken"),
+            
+            // Save token to device storage
+            Dictionary({
+                "jitToken": GetVariable("jitToken")
+            }),
+            SetVariable("JIT Enabler Data", true) // Save to device storage
+        ]
+    })
+);
+
+// App selection menu
+shortcut.add(
+    ShowResult("Select the app you want to enable JIT for:"),
+    
+    Menu("Select an app to enable JIT", {
+        "Emulators": [
+            List("Select an emulator app", [
+                "Delta Emulator",
+                "PPSSPP",
+                "UTM",
+                "iNDS",
+                "Provenance",
+                "Other (Enter Bundle ID)"
+            ]),
+            
+            // Handle "Other" option
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "Other (Enter Bundle ID)",
+                then: [
+                    Ask("Enter the bundle ID of the app (e.g., com.example.app)"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle Delta Emulator
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "Delta Emulator",
+                then: [
+                    Text("com.rileytestut.Delta"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle PPSSPP
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "PPSSPP",
+                then: [
+                    Text("org.ppsspp.ppsspp"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle UTM
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "UTM",
+                then: [
+                    Text("com.utmapp.UTM"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle iNDS
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "iNDS",
+                then: [
+                    Text("net.nerd.iNDS"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle Provenance
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "Provenance",
+                then: [
+                    Text("org.provenance-emu.provenance"),
+                    SetVariable("bundleID")
+                ]
+            })
+        ],
+        
+        "JavaScript Apps": [
+            List("Select a JavaScript app", [
+                "JavaScriptCore",
+                "WebKit-based App",
+                "React Native App",
+                "Other (Enter Bundle ID)"
+            ]),
+            
+            // Handle "Other" option
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "Other (Enter Bundle ID)",
+                then: [
+                    Ask("Enter the bundle ID of the app (e.g., com.example.app)"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle JavaScriptCore
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "JavaScriptCore",
+                then: [
+                    Text("com.apple.JavaScriptCore"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle WebKit-based App
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "WebKit-based App",
+                then: [
+                    Ask("Enter the bundle ID of the WebKit-based app"),
+                    SetVariable("bundleID")
+                ]
+            }),
+            
+            // Handle React Native App
+            If({
+                input: GetVariable("Chosen Item"),
+                condition: "is",
+                value: "React Native App",
+                then: [
+                    Ask("Enter the bundle ID of the React Native app"),
+                    SetVariable("bundleID")
+                ]
+            })
+        ],
+        
+        "Other Apps": [
+            Ask("Enter the bundle ID of the app you want to enable JIT for"),
+            SetVariable("bundleID")
+        ]
+    })
+);
+
+// Request JIT enablement
+shortcut.add(
+    ShowResult("Enabling JIT for " + GetVariable("bundleID") + "..."),
+    
+    // Create app info dictionary
+    Dictionary({
+        "bundle_id": GetVariable("bundleID"),
+        "ios_version": GetVariable("iosVersion")
+    }),
+    
+    // Send JIT enablement request
+    GetContentsOfURL({
+        url: GetVariable("backendURL") + "/enable-jit",
+        method: "POST",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": "Bearer " + GetVariable("jitToken")
+        },
+        body: "JSON"
+    }),
+    SetVariable("jitResponse"),
+    
+    // Check if JIT was enabled successfully
+    If({
+        input: GetVariable("jitResponse.status"),
+        condition: "contains",
+        value: "JIT enabled",
+        then: [
+            // Show success message
+            ShowResult("JIT enabled successfully! Launching app..."),
+            
+            // Save JIT session ID
+            GetVariable("jitResponse.session_id"),
+            SetVariable("jitSessionID"),
+            
+            // Launch the app
+            OpenApp(GetVariable("bundleID"))
+        ],
+        else: [
+            // Show error message
+            ShowResult("Error enabling JIT: " + GetVariable("jitResponse.error"))
+        ]
+    })
+);
+
+// Error handling for network issues
+shortcut.add(
+    If({
+        input: GetVariable("jitResponse"),
+        condition: "equals",
+        value: "null",
+        then: [
+            ShowResult("Network error: Could not connect to JIT backend server. Please check your connection and try again.")
+        ]
+    })
+);
+
+// Export the shortcut
+export default shortcut;

--- a/JIT Backend/app.py
+++ b/JIT Backend/app.py
@@ -227,11 +227,26 @@ def index():
 @app.route('/download-shortcut', methods=['GET'])
 def download_shortcut():
     """Download the JIT Enabler Shortcut"""
-    shortcut_path = os.path.join(os.path.dirname(__file__), 'JIT_Enabler_Shortcut.json')
-    return send_file(shortcut_path, 
-                    mimetype='application/json',
-                    as_attachment=True,
-                    download_name='JIT_Enabler.shortcut')
+    shortcut_type = request.args.get('type', 'json')
+    
+    if shortcut_type == 'jellycuts':
+        shortcut_path = os.path.join(os.path.dirname(__file__), 'JIT_Enabler.jellycuts')
+        return send_file(shortcut_path, 
+                        mimetype='text/plain',
+                        as_attachment=True,
+                        download_name='JIT_Enabler.jellycuts')
+    else:
+        shortcut_path = os.path.join(os.path.dirname(__file__), 'JIT_Enabler_Shortcut.json')
+        return send_file(shortcut_path, 
+                        mimetype='application/json',
+                        as_attachment=True,
+                        download_name='JIT_Enabler.shortcut')
+
+@app.route('/JELLYCUTS_README.md', methods=['GET'])
+def jellycuts_readme():
+    """Serve the Jellycuts README file"""
+    readme_path = os.path.join(os.path.dirname(__file__), 'JELLYCUTS_README.md')
+    return send_file(readme_path, mimetype='text/markdown')
 
 @app.route('/health', methods=['GET'])
 def health_check():

--- a/JIT Backend/templates/index.html
+++ b/JIT Backend/templates/index.html
@@ -251,9 +251,19 @@
         <div class="shortcut-box">
             <img src="https://help.apple.com/assets/6231D2AAFC8AD1B76D67A55B/6231D2ACFC8AD1B76D67A562/en_US/8b631353a441420c74e54416e4a0e83e.png" alt="Shortcuts Icon" class="shortcut-icon">
             <h3>JIT Enabler Shortcut</h3>
-            <p>Tap the button below to download the shortcut to your iOS device.</p>
-            <a href="/download-shortcut" class="btn">Download Shortcut</a>
-            <p style="margin-top: 16px;">Or scan this QR code:</p>
+            <p>Choose your preferred format to download the shortcut:</p>
+            
+            <div style="display: flex; justify-content: center; gap: 16px; margin: 20px 0;">
+                <a href="/download-shortcut" class="btn">Download Standard Shortcut</a>
+                <a href="/download-shortcut?type=jellycuts" class="btn" style="background-color: var(--success-color);">Download Jellycuts Version</a>
+            </div>
+            
+            <div style="margin-top: 20px; padding: 15px; background-color: rgba(255, 149, 0, 0.1); border-radius: 8px;">
+                <h4 style="color: var(--warning-color); margin-bottom: 10px;">Why use Jellycuts?</h4>
+                <p>The Jellycuts version doesn't require signing and can be easily customized. <a href="/JELLYCUTS_README.md" style="color: var(--primary-color);">Learn more</a></p>
+            </div>
+            
+            <p style="margin-top: 16px;">Or scan this QR code for the standard version:</p>
             <img src="https://api.qrserver.com/v1/create-qr-code/?size=200x200&data={{ request.url_root }}download-shortcut" alt="QR Code" class="qr-code">
         </div>
 


### PR DESCRIPTION
This PR adds a Jellycuts version of the JIT Enabler shortcut, which provides the same functionality without requiring signing. It includes:

- New Jellycuts shortcut file
- Detailed README for Jellycuts users
- Updated Flask app to serve both shortcut versions
- Updated web interface with download options for both versions